### PR TITLE
Enhancement - Round Displayed Total Points of Player Pieces

### DIFF
--- a/_UI/Score/Score.gd
+++ b/_UI/Score/Score.gd
@@ -14,7 +14,7 @@ func SetNum(n):
 		Num.position = Vector2(-30,-30)
 	else:
 		Num.position = Vector2(-17,-30)
-	Num.SetText(str(n))
+	Num.SetText(str(int(n)))
 
 func SetL(n:int,c:Color):
 	if n>curL:


### PR DESCRIPTION
Optional enhancement to prevent rendering a floating point after the Godot 4.4 upgrade.

## Implementation Details

The rounding issue only happens if the project migrates from Godot 4.3 into Godot 4.4. Maybe it already has been on a private branch, but it is an easy 1-line fix so I wanted to share it in case it is helpful to you. Thank you for making this awesome strategy game.

Cherry picked from commit 21069b0ccb44534a96db7d7b055b5341a69d12cf of a PR upgrading a fork of this project to Godot 4.4 for fun (https://github.com/NBumgardner/Tiny-Checker/pull/1).

## Screenshot

![2025-05-17_ld-56_tiny-checker_godot-4-4-version_comparison_round-top-number](https://github.com/user-attachments/assets/7bedc545-2a09-4116-9931-26f76df302bb)
_**Screenshot 1:** Comparison screenshot of before and after the 1-line enhancement is added to a Godot 4.4 version of the Tiny Checkers game's battle phase, where the left side is upgrade to Godot 4.4 but has not yet fixed the rounding issue Godot 4.4 introduces._